### PR TITLE
Removing test_runMICP3DCase.m

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,4 +36,3 @@ jobs:
       run: |
         pushd MRST/modules/ad-micp
         octave tests/test_runMICP1DCase.m
-        octave tests/test_runMICP3DCase.m

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ rm -rf ad-micp
 git clone https://github.com/daavid00/ad-micp.git
 ``` 
 
-Then you can try to run the tests, e.g., the [_test_runMICP1DCase.m_](https://github.com/daavid00/ad-micp/blob/main/tests/test_runMICP1DCase.m) using octave (octave can be installed by executing `brew install octave`):
+Then you can try to run the [_test_runMICP1DCase.m_](https://github.com/daavid00/ad-micp/blob/main/tests/test_runMICP1DCase.m) using octave (octave can be installed by executing `brew install octave`):
 
 ```bash
 octave tests/test_runMICP1DCase.m

--- a/tests/test_runMICP3DCase.m
+++ b/tests/test_runMICP3DCase.m
@@ -1,3 +1,0 @@
-run("../../startup.m")
-run("examples/runMICP3DCase.m")
-assert (isfile("statesCO2afterMICP-00030.vtu"), "The runMICP3DCase.m failed")


### PR DESCRIPTION
This since it launches a user request, leading to the test to fail in the CI:

`Do you want to download dataset 'CO2lab_Sampled_Tables' (102.80 MB), Y/N [Y]:`